### PR TITLE
TPB21: Donation page first section

### DIFF
--- a/src/pages/Donation/Donation.jsx
+++ b/src/pages/Donation/Donation.jsx
@@ -1,0 +1,11 @@
+import HelpNow from './components/HelpNow/HelpNow';
+
+const Donation = () => {
+  return (
+    <>
+      <HelpNow />
+    </>
+  );
+};
+
+export default Donation;

--- a/src/pages/Donation/components/HelpNow/HelpNow.jsx
+++ b/src/pages/Donation/components/HelpNow/HelpNow.jsx
@@ -1,0 +1,66 @@
+import {
+  Container,
+  HelpOption,
+  HelpOptionsContainer,
+  HelpInfoContainer,
+  ChipsContainer,
+} from './HelpNow.style';
+import { Highlight } from '../../../../shared/components';
+
+const HelpNow = () => {
+  return (
+    <Container>
+      <h1>
+        <Highlight>Ajude</Highlight> agora mesmo
+      </h1>
+      <ChipsContainer>
+        <p>R$15</p>
+        <p>R$30</p>
+        <p>R$50</p>
+        <p>R$100</p>
+        <p>R$200</p>
+        <p>Qualquer valor</p>
+      </ChipsContainer>
+      <HelpInfoContainer>
+        <p style={{ fontWeight: 'bold' }}>
+          Para <Highlight>ajudar</Highlight> com qualquer valor é fácil:
+        </p>
+        <HelpOptionsContainer>
+          <HelpOption>
+            <strong>
+              <Highlight>Pix</Highlight>
+            </strong>
+            <p>A nossa chave pix é:</p>
+            <p>443.198.918-80</p>
+          </HelpOption>
+          <HelpOption>
+            <strong>
+              <Highlight>Transferência bancária</Highlight>
+            </strong>
+            <p>Banco Nu Pagamentos S.A</p>
+            <p>Agência 0001</p>
+            <p>Conta 20718046-2</p>
+            <p>Nome: Gustavo Zaborowsky Graicer</p>
+          </HelpOption>
+          <HelpOption>
+            <strong>
+              <Highlight>Boleto bancário</Highlight>
+            </strong>
+            <p>
+              Envie um e-mail para{' '}
+              <strong>financeiro.saudedarua@gmail.com</strong> indicando o valor
+              da doação.
+            </p>
+            <p>Iremos te responder com o boleto para pagamento!</p>
+          </HelpOption>
+        </HelpOptionsContainer>
+      </HelpInfoContainer>
+      <p>
+        Obrigado por acreditar em nós.{' '}
+        <Highlight>Juntos faremos a diferença!</Highlight>
+      </p>
+    </Container>
+  );
+};
+
+export default HelpNow;

--- a/src/pages/Donation/components/HelpNow/HelpNow.jsx
+++ b/src/pages/Donation/components/HelpNow/HelpNow.jsx
@@ -5,7 +5,7 @@ import {
   HelpInfoContainer,
   ChipsContainer,
 } from './HelpNow.style';
-import { Highlight } from '../../../../shared/components';
+import { Highlight, Chip } from '../../../../shared/components';
 
 const HelpNow = () => {
   return (
@@ -14,12 +14,12 @@ const HelpNow = () => {
         <Highlight>Ajude</Highlight> agora mesmo
       </h1>
       <ChipsContainer>
-        <p>R$15</p>
-        <p>R$30</p>
-        <p>R$50</p>
-        <p>R$100</p>
-        <p>R$200</p>
-        <p>Qualquer valor</p>
+        <Chip>R$ 15</Chip>
+        <Chip>R$ 30</Chip>
+        <Chip>R$ 50</Chip>
+        <Chip>R$ 100</Chip>
+        <Chip>R$ 200</Chip>
+        <Chip selected>Qualquer valor</Chip>
       </ChipsContainer>
       <HelpInfoContainer>
         <p style={{ fontWeight: 'bold' }}>

--- a/src/pages/Donation/components/HelpNow/HelpNow.jsx
+++ b/src/pages/Donation/components/HelpNow/HelpNow.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Container,
   HelpOption,
@@ -8,18 +9,36 @@ import {
 import { Highlight, Chip } from '../../../../shared/components';
 
 const HelpNow = () => {
+  const defaultSelection = 'Qualquer valor';
+  const values = [
+    'R$ 15',
+    'R$ 30',
+    'R$ 50',
+    'R$ 100',
+    'R$ 200',
+    defaultSelection,
+  ];
+  const [selectedValue, setSelectedValue] = useState(defaultSelection);
+
+  const handleSelection = (value) => {
+    setSelectedValue(value);
+  };
+
   return (
     <Container>
       <h1>
         <Highlight>Ajude</Highlight> agora mesmo
       </h1>
       <ChipsContainer>
-        <Chip>R$ 15</Chip>
-        <Chip>R$ 30</Chip>
-        <Chip>R$ 50</Chip>
-        <Chip>R$ 100</Chip>
-        <Chip>R$ 200</Chip>
-        <Chip selected>Qualquer valor</Chip>
+        {values.map((v) => (
+          <Chip
+            key={v}
+            onClick={() => handleSelection(v)}
+            selected={selectedValue === v}
+          >
+            {v}
+          </Chip>
+        ))}
       </ChipsContainer>
       <HelpInfoContainer>
         <p style={{ fontWeight: 'bold' }}>

--- a/src/pages/Donation/components/HelpNow/HelpNow.style.js
+++ b/src/pages/Donation/components/HelpNow/HelpNow.style.js
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  text-align: center;
+
+  > p {
+    font-weight: bold;
+  }
+`;
+
+export const ChipsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  margin: 64px 0;
+`;
+
+export const HelpOptionsContainer = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+`;
+
+export const HelpOption = styled.div`
+  text-align: left;
+  padding: 8px;
+  max-width: 30%;
+`;
+
+export const HelpInfoContainer = styled.div`
+  box-sizing: border-box;
+  > * {
+    margin: 32px 0;
+  }
+`;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,3 +1,4 @@
 import Home from './Home/Home';
+import Donation from './Donation/Donation';
 
-export { Home };
+export { Home, Donation };

--- a/src/routes/AppRoutes.jsx
+++ b/src/routes/AppRoutes.jsx
@@ -1,12 +1,12 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from '../shared/components';
-import { Home } from '../pages';
+import { Home, Donation } from '../pages';
 
 const AppRoutes = () => (
   <Routes>
     <Route path="/" element={<Layout />}>
       <Route index element={<Home />} />
-      <Route path="doacao" element={() => <div></div>} />
+      <Route path="doacao" element={<Donation />} />
     </Route>
   </Routes>
 );

--- a/src/shared/components/Chip/Chip.jsx
+++ b/src/shared/components/Chip/Chip.jsx
@@ -1,0 +1,7 @@
+import { Container } from './Chip.style';
+
+const Chip = ({ children, ...rest }) => {
+  return <Container {...rest}>{children}</Container>;
+};
+
+export default Chip;

--- a/src/shared/components/Chip/Chip.style.js
+++ b/src/shared/components/Chip/Chip.style.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+export const Container = styled.span`
+  display: block;
+  color: ${({ theme, selected }) =>
+    selected ? theme.colors.primary_light : theme.colors.primary};
+  min-width: 96px;
+  border-style: solid;
+  border-color: ${({ theme }) => theme.colors.primary};
+  background-color: ${({ theme, selected }) =>
+    selected ? theme.colors.primary : 'transparent'};
+  padding: 8px 16px;
+  border-radius: 80px;
+  cursor: pointer;
+`;

--- a/src/shared/components/Chip/Chip.style.js
+++ b/src/shared/components/Chip/Chip.style.js
@@ -12,4 +12,9 @@ export const Container = styled.span`
   padding: 8px 16px;
   border-radius: 80px;
   cursor: pointer;
+  :hover {
+    background-color: ${({ theme }) => theme.colors.light};
+    color: ${({ theme }) => theme.colors.dark};
+    border-color: transparent;
+  }
 `;

--- a/src/shared/components/Highlight/Highlight.jsx
+++ b/src/shared/components/Highlight/Highlight.jsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const Highlight = styled.span`
+  color: ${(props) => props.theme.colors.primary};
+`;
+
+export default Highlight;

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -3,5 +3,6 @@ import Header from './Header/components/Header';
 import ButtonDonation from './Button/Button';
 import Layout from './Layout/Layout';
 import Highlight from './Highlight/Highlight';
+import Chip from './Chip/Chip';
 
-export { Layout, Structure, Header, ButtonDonation, Highlight };
+export { Layout, Structure, Header, ButtonDonation, Highlight, Chip };

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -2,5 +2,6 @@ import Structure from './Structure/Structure';
 import Header from './Header/components/Header';
 import ButtonDonation from './Button/Button';
 import Layout from './Layout/Layout';
+import Highlight from './Highlight/Highlight';
 
-export { Layout, Structure, Header, ButtonDonation };
+export { Layout, Structure, Header, ButtonDonation, Highlight };


### PR DESCRIPTION
# First section of Donation's page

Add the donation page itself with content of the first section: *Help Now*.

__Key Points__

- Add Donation Page component
- Add First section of the page (`HelpNow` component)
- Add shared component `Highlight`
- Add shared component `Chip`
-  State logic for donation value selection
---

__Further Considerations__

1. Hover state style was not specified for the `Chip` component. Meanwhile I have done that style by myself, but I believe we should consult UX team to validate the style for the hover state and adjust it in the future as needed. 
2. The action of select a specified value for donation is not giving any feedback so far (only appears to be selected on `Chip` component). The code responsible for showing the donation component and the donation component itself which contains the QR code will be implemented in the next update.